### PR TITLE
MERGE (About) Change email to address

### DIFF
--- a/about/index.php
+++ b/about/index.php
@@ -123,7 +123,7 @@
             <h3>Accuracy</h3>
             <p>While every effort has been made to ensure that the data contained in these files is correct and up-to-date, occasionally mistakes do get made and errors slip into the final production files.</p>
             <p>The Revd Gareth J M Saunders will not be held accountable for any issues that arise from the use of these files. You use them entirely at your own risk.</p>
-            <p>To report any errors please <a href="mailto:gareth@garethjmsaunders.co.uk">email Gareth J M Saunders</a>.</p>
+            <p>To report any errors please email <a href="mailto:gareth@garethjmsaunders.co.uk">gareth@garethjmsaunders.co.uk</a>.</p>
             <h3>Church of England edition</h3>
             <p>See Fr Simon Rundell's <a href="http://frsimon.wordpress.com/electric-ordo/">Electronic Ordo</a> containing daily information and readings for Mass each day according to both the Anglican (Common Worship) or Roman lectionaries.</p>
             <h3>Roman Catholic editions</h3>


### PR DESCRIPTION
I noticed that the About page invited users to email me but the email address has "email Gareth J M Saunders" as the link text. It occurred to me that some users may prefer to write down the email address or at least see it clearly, e.g. on a mobile device.