### PR TITLE
MERGE (PHP functions) Change how it determines the server

### DIFF
--- a/php/functions.php
+++ b/php/functions.php
@@ -11,7 +11,8 @@ function get_navigation($option) {
 		);
 		echo CNavigation::GenerateMenu($menuItems);
 	} elseif ($option === 'homepath') {
-		if ($_SERVER['HTTP_HOST'] === 'localhost') {
+		// See CNavigation class
+		if ($_SERVER['SERVER_NAME'] === 'localhost') {
 			$homepath = '/sec-digital-calendar-website/';
 		} else {
 			$homepath = '/';
@@ -35,13 +36,18 @@ class CNavigation {
 		$currentDirectory      = $directories[$currentDirectoryIndex];
 
 		// Which server?
-		if ($server === 'www.seccalendar.co.uk') {
-			$location = 'remote';
-			$root = $remoteRoot;
-		} else {
+		// This used to be the other way round, defining the name of the
+		// remote server but it had to be changed if the site moved domain.
+		// This is more robust, simply looking for localhost.
+		if ($server === 'localhost') {
 			$location = 'local';
 			$root = $localRoot;
+		} else {
+			$location = 'remote';
+			$root = $remoteRoot;
 		}
+
+
 
 		// Homepage or subpage?
 		if ($path === $remoteRoot || $path === $localRoot) {


### PR DESCRIPTION
The old way (HTTP_HOST) worked fine on SiteGround but not Tsohost. It requires SERVER_NAME.
In the navigation class I've switched things around so that it specifically looks for localhost rather than needing to define a domain name. This makes the code more portable.