### PR TITLE
MERGE (Homepage) Add abbr to SPB

### DIFF
--- a/index.php
+++ b/index.php
@@ -156,7 +156,25 @@
                 $target.toggle('slow').addClass('js-selected');
                 $this.addClass('js-selected-row');
             }
-        });    
+        });
+
+        // === SPB ABBR ====================
+
+        // Today: SPB field
+        $(".spb:contains('SPB')").html(function(_, html) {
+           return  html.replace(/(SPB)/g, '<abbr title="Scottish Prayer Book" class="spb">$1</abbr>')
+        });
+
+        // Today: Readings field
+        $(".readings-collect:contains('SPB')").html(function(_, html) {
+           return  html.replace(/(SPB)/g, '<abbr title="Scottish Prayer Book" class="spb">$1</abbr>')
+        });
+
+        // Next: Readings
+        $(".next-readings-div:contains('SPB')").html(function(_, html) {
+           return  html.replace(/(SPB)/g, '<abbr title="Scottish Prayer Book" class="spb">$1</abbr>')
+        });
+
     });
 
 </script>


### PR DESCRIPTION
SPB (Scottish Prayer Book) is not obvious to casual observers. Use the HTML abbr tag to add a hover tooltip to explain the abbreviation.

Use jQuery to search for instances of SPB in the text and dynamically replace this. This information is provided in a CSV file so it is impractical to mark that up as it is used for a variety of purposes.